### PR TITLE
Completed time and lock text area

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,5 @@ jobs:
           npm run build
       # - name: Run test with coverage
       #   run: pnpm run coverage
-      - name: Convext Deploy
-        run: npx convex deploy
       - name: Test
         run: npm run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,5 +35,7 @@ jobs:
           npm run build
       # - name: Run test with coverage
       #   run: pnpm run coverage
+      - name: Convext Deploy
+        run: npx convex deploy
       - name: Test
         run: npm run test

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -25,6 +25,7 @@ export default function Page(props: PageParams) {
 
   const createSlug = useMutation(api.slugs.createSlug);
   const [slugId, setSlugId] = useState<Id<"slugs"> | undefined>(undefined);
+
   const convex = useConvex();
   const getSlug = useQuery(api.slugs.getSlug, {
     slug: slug,
@@ -46,6 +47,7 @@ export default function Page(props: PageParams) {
     if (!getTheSlug) {
       const res = await createSlug({
         slug: slug,
+        docText: "",
       });
 
       setSlugId(res as Id<"slugs">);

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -18,25 +18,29 @@ interface PageParams {
     slug: string;
   };
 }
+interface slugData {
+  _id: Id<"slugs">;
+  _creationTime: number;
+  passedTests?: number | undefined;
+  failedTests?: number | undefined;
+  endTime?: number | undefined;
+  slug: string;
+  startTime: number;
+  docText: string;
+}
+
 export default function Page(props: PageParams) {
   const { params } = props;
   const { slug } = params;
-  const [usersInRoom, setUsersInRoom] = useState<string[]>([]);
-
   const createSlug = useMutation(api.slugs.createSlug);
-  const [slugId, setSlugId] = useState<Id<"slugs"> | undefined>(undefined);
+  const [usersInRoom, setUsersInRoom] = useState<string[]>([]);
+  const [slugId, setSlugId] = useState<Id<"slugs"> | undefined>();
   const [textDelta, setTextDelta] = useState<string>("");
-
+  const [currentSlugData, setCurrentSlugData] = useState<slugData | null>();
   const convex = useConvex();
-  const getSlug = useQuery(api.slugs.getSlug, {
-    slug: slug,
-  });
 
   useEffect(() => {
     createSlugFn();
-    if (getSlug) {
-      setSlugId(getSlug._id);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -44,6 +48,7 @@ export default function Page(props: PageParams) {
     const getTheSlug = await convex.query(api.slugs.getSlug, {
       slug: slug,
     });
+    setCurrentSlugData(getTheSlug);
 
     if (!getTheSlug) {
       const res = await createSlug({
@@ -66,14 +71,14 @@ export default function Page(props: PageParams) {
           <div>
             <h3 className="text-2xl">{slug ? `Room: ${slug}` : ""}</h3>
             <h3>Editors Online: {usersInRoom.length + 1}</h3>
-            {getSlug ? (
-              !getSlug.endTime ? (
-                <RoomTimer start={getSlug.startTime} />
+            {currentSlugData ? (
+              !currentSlugData.endTime ? (
+                <RoomTimer start={currentSlugData.startTime} />
               ) : (
                 <>
                   {`Completed in: ${timeElapsed({
-                    start: getSlug.startTime,
-                    end: getSlug.endTime || Date.now(),
+                    start: currentSlugData.startTime,
+                    end: currentSlugData.endTime || Date.now(),
                   })}`}
                 </>
               )

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { Id } from "@/convex/_generated/dataModel";
 import RoomTimer from "../components/Timer/RoomTimer";
 import { timeElapsed } from "../components/Timer/utils";
+import { DeltaStatic } from "../components/TextEditor";
 
 // we must disable SSR since ReactQuill attempts to access the `document`
 const DocumentWrapper = dynamic(() => import("../components/DocumentWrapper"), {
@@ -25,6 +26,7 @@ export default function Page(props: PageParams) {
 
   const createSlug = useMutation(api.slugs.createSlug);
   const [slugId, setSlugId] = useState<Id<"slugs"> | undefined>(undefined);
+  const [textDelta, setTextDelta] = useState<string>("");
 
   const convex = useConvex();
   const getSlug = useQuery(api.slugs.getSlug, {
@@ -53,6 +55,7 @@ export default function Page(props: PageParams) {
       setSlugId(res as Id<"slugs">);
     } else {
       setSlugId(getTheSlug._id);
+      setTextDelta(getTheSlug.docText);
     }
   }
 
@@ -84,6 +87,8 @@ export default function Page(props: PageParams) {
           slug={slug}
           slugId={slugId}
           setUsersInRoom={setUsersInRoom}
+          textDelta={textDelta}
+          setTextDelta={setTextDelta}
         />
       </div>
     </main>

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMutation, useQuery } from "convex/react";
+import { useConvex, useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useEffect, useState } from "react";
 import { Id } from "@/convex/_generated/dataModel";
@@ -25,21 +25,33 @@ export default function Page(props: PageParams) {
 
   const createSlug = useMutation(api.slugs.createSlug);
   const [slugId, setSlugId] = useState<Id<"slugs"> | undefined>(undefined);
+  const convex = useConvex();
   const getSlug = useQuery(api.slugs.getSlug, {
     slug: slug,
   });
 
   useEffect(() => {
     createSlugFn();
+    if (getSlug) {
+      setSlugId(getSlug._id);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function createSlugFn() {
-    const res = await createSlug({
+    const getTheSlug = await convex.query(api.slugs.getSlug, {
       slug: slug,
     });
 
-    setSlugId(res as Id<"slugs">);
+    if (!getTheSlug) {
+      const res = await createSlug({
+        slug: slug,
+      });
+
+      setSlugId(res as Id<"slugs">);
+    } else {
+      setSlugId(getTheSlug._id);
+    }
   }
 
   return (

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { api } from "@/convex/_generated/api";
 import { useEffect, useState } from "react";
 import { Id } from "@/convex/_generated/dataModel";
 import RoomTimer from "../components/Timer/RoomTimer";
+import { timeElapsed } from "../components/Timer/utils";
 
 // we must disable SSR since ReactQuill attempts to access the `document`
 const DocumentWrapper = dynamic(() => import("../components/DocumentWrapper"), {
@@ -50,7 +51,16 @@ export default function Page(props: PageParams) {
             <h3 className="text-2xl">{slug ? `Room: ${slug}` : ""}</h3>
             <h3>Editors Online: {usersInRoom.length + 1}</h3>
             {getSlug ? (
-              <RoomTimer start={getSlug._creationTime} />
+              !getSlug.endTime ? (
+                <RoomTimer start={getSlug.startTime} />
+              ) : (
+                <>
+                  {`Completed in: ${timeElapsed({
+                    start: getSlug.startTime,
+                    end: getSlug.endTime || Date.now(),
+                  })}`}
+                </>
+              )
             ) : (
               <div>Loading...</div>
             )}

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from "react";
 import { Id } from "@/convex/_generated/dataModel";
 import RoomTimer from "../components/Timer/RoomTimer";
 import { timeElapsed } from "../components/Timer/utils";
-import { DeltaStatic } from "../components/TextEditor";
 
 // we must disable SSR since ReactQuill attempts to access the `document`
 const DocumentWrapper = dynamic(() => import("../components/DocumentWrapper"), {

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -69,7 +69,6 @@ export default function Page(props: PageParams) {
         <DocumentWrapper
           slug={slug}
           slugId={slugId}
-          usersInRoom={usersInRoom}
           setUsersInRoom={setUsersInRoom}
         />
       </div>

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -11,12 +11,11 @@ import type { Dispatch, SetStateAction } from "react";
 interface DocumentWrapperProps {
   slug: string;
   slugId: Id<"slugs"> | undefined;
-  usersInRoom: string[];
   setUsersInRoom: Dispatch<SetStateAction<string[]>>;
 }
 export default function DocumentWrapper(props: DocumentWrapperProps) {
   const updateSlug = useMutation(api.slugs.updateSlug);
-  const { slug, slugId, usersInRoom, setUsersInRoom } = props;
+  const { slug, slugId, setUsersInRoom } = props;
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
@@ -41,7 +40,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         setFailedRules={setFailedRules}
         setIsCompleted={setIsCompleted}
         setUsersInRoom={setUsersInRoom}
-        usersInRoom={usersInRoom}
+        isCompleted={isCompleted}
       />
       <RuleSet passedRules={passedRules} failedRules={failedRules} />
     </div>

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import RuleSet from "./RuleSet/RuleSet";
-import TextEditor from "./TextEditor";
+import TextEditor, { DeltaStatic } from "./TextEditor";
 import { Rule } from "./RuleSet/Rules";
 import { api } from "@/convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";
@@ -13,10 +13,12 @@ interface DocumentWrapperProps {
   slug: string;
   slugId: Id<"slugs"> | undefined;
   setUsersInRoom: Dispatch<SetStateAction<string[]>>;
+  textDelta: string;
+  setTextDelta: Dispatch<SetStateAction<string>>;
 }
 export default function DocumentWrapper(props: DocumentWrapperProps) {
   const updateSlug = useMutation(api.slugs.updateSlug);
-  const { slug, slugId, setUsersInRoom } = props;
+  const { slug, slugId, setUsersInRoom, textDelta, setTextDelta } = props;
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
@@ -24,12 +26,13 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
 
   useEffect(() => {
     if (slugId) {
+      console.log("updating slug:", textDelta);
       updateSlug({
         id: slugId,
         passedTests: passedRules.length,
         failedTests: failedRules.length,
         endTime: isCompleted ? Date.now() : undefined,
-        docText: text?.toJSON() ?? "",
+        docText: textDelta,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,6 +49,8 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         isCompleted={isCompleted}
         text={text}
         setText={setText}
+        setTextDelta={setTextDelta}
+        textDelta={textDelta}
       />
       <RuleSet passedRules={passedRules} failedRules={failedRules} />
     </div>

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -18,35 +18,12 @@ interface DocumentWrapperProps {
 }
 
 export default function DocumentWrapper(props: DocumentWrapperProps) {
-  const updateSlug = useMutation(api.slugs.updateSlug);
-
-  const { slug, slugId, setUsersInRoom, textDelta, setTextDelta } = props;
-  const [passedRules, setPassedRules] = useState<Rule[]>([]);
-  const [failedRules, setFailedRules] = useState<Rule[]>([]);
-  const [isCompleted, setIsCompleted] = useState<boolean>(false);
-  const [text, setText] = useState<Y.Text>();
-
   const { slug, slugId, setUsersInRoom, textDelta, setTextDelta } = props;
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [text, setText] = useState<Y.Text>();
-
-
-  useEffect(() => {
-    if (slugId) {
-      console.log("updating slug:", textDelta);
-      updateSlug({
-        id: slugId,
-        passedTests: passedRules.length,
-        failedTests: failedRules.length,
-        endTime: isCompleted ? Date.now() : undefined,
-        docText: textDelta,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [passedRules, failedRules]);
 
   return (
     <div className="flex justify-center content-center flex-row gap-5">
@@ -62,6 +39,9 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         setTextDelta={setTextDelta}
         textDelta={textDelta}
         setIsLoaded={setIsLoaded}
+        slugId={slugId}
+        passedRules={passedRules}
+        failedRules={failedRules}
       />
       <RuleSet
         passedRules={passedRules}

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import RuleSet from "./RuleSet/RuleSet";
-import TextEditor, { DeltaStatic } from "./TextEditor";
+import TextEditor from "./TextEditor";
 import { Rule } from "./RuleSet/Rules";
 import { api } from "@/convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -5,6 +5,7 @@ import { Rule } from "./RuleSet/Rules";
 import { api } from "@/convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";
 import { Id } from "@/convex/_generated/dataModel";
+import * as Y from "yjs";
 
 import type { Dispatch, SetStateAction } from "react";
 
@@ -19,6 +20,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
+  const [text, setText] = useState<Y.Text>();
 
   useEffect(() => {
     if (slugId) {
@@ -27,6 +29,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         passedTests: passedRules.length,
         failedTests: failedRules.length,
         endTime: isCompleted ? Date.now() : undefined,
+        docText: text?.toJSON() ?? "",
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -41,6 +44,8 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         setIsCompleted={setIsCompleted}
         setUsersInRoom={setUsersInRoom}
         isCompleted={isCompleted}
+        text={text}
+        setText={setText}
       />
       <RuleSet passedRules={passedRules} failedRules={failedRules} />
     </div>

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -27,7 +27,7 @@ interface TextEditorProps extends ReactQuillProps {
   setFailedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   setUsersInRoom: React.Dispatch<React.SetStateAction<string[]>>;
-  usersInRoom: string[];
+  isCompleted: boolean;
 }
 
 export default function TextEditor(props: TextEditorProps) {
@@ -37,7 +37,7 @@ export default function TextEditor(props: TextEditorProps) {
     setIsCompleted,
     slug,
     setUsersInRoom,
-    usersInRoom,
+    isCompleted,
   } = props;
   const [text, setText] = useState<Y.Text>();
   const [provider, setProvider] = useState<WebrtcProviderType>();
@@ -102,6 +102,7 @@ export default function TextEditor(props: TextEditorProps) {
         setFailedRules={setFailedRules}
         setPassedRules={setPassedRules}
         setIsCompleted={setIsCompleted}
+        isCompleted={isCompleted}
         slug={slug}
       />
     </div>
@@ -115,6 +116,7 @@ type EditorProps = {
   setFailedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   slug: string;
+  isCompleted: boolean;
 };
 
 function QuillEditor(props: EditorProps) {
@@ -126,6 +128,7 @@ function QuillEditor(props: EditorProps) {
     setFailedRules,
     setIsCompleted,
     slug,
+    isCompleted,
   } = props;
   const reactQuillRef = useRef<ReactQuill>(null);
   // Set up Yjs and Quill
@@ -175,6 +178,7 @@ function QuillEditor(props: EditorProps) {
         <ReactQuill
           className="h-full w-full block px-0 text-sm text-gray-800 bg-white border-0 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400 focus:ring-0 focus:ring-offset-0"
           ref={reactQuillRef}
+          readOnly={isCompleted}
           modules={{
             toolbar: false,
             cursors: {

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -50,13 +50,10 @@ export default function TextEditor(props: TextEditorProps) {
   } = props;
 
   const [provider, setProvider] = useState<WebrtcProviderType>();
-  // console.log(provider?.room?.bcConns.size);
 
   useEffect(() => {
     const yDoc = new Y.Doc();
     const yText = yDoc.getText(slug);
-
-    // setTextDelta(yText.toString());
 
     // default: ~20 max connections. Updated ~75 max connections
     const yProvider: WebrtcProviderType = new WebrtcProvider(slug, yDoc, {
@@ -72,11 +69,11 @@ export default function TextEditor(props: TextEditorProps) {
       "change",
       ({
         added,
-        updated,
+        _updated,
         removed,
       }: {
         added: string[];
-        updated: string[];
+        _updated: string[];
         removed: string[];
       }) => {
         setUsersInRoom((prev) => {
@@ -84,13 +81,6 @@ export default function TextEditor(props: TextEditorProps) {
           removed.forEach((user) => newUsers.delete(user));
           return Array.from(newUsers);
         });
-
-        // if (yProvider?.room?.bcConns.size === 0) {
-        //   // yText.insert(0, "abcde");
-
-        // }
-        // console.log("text", yText);
-        // setTextDelta(yText.toDelta());
       }
     );
 
@@ -105,10 +95,6 @@ export default function TextEditor(props: TextEditorProps) {
     // Do not add slug to dependency arr or it will break everything
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // useEffect(() => {
-  //   console.log("yText", text);
-  // }, []);
 
   // TODO proper error handling
   if (!text || !provider) {
@@ -187,13 +173,6 @@ function QuillEditor(props: EditorProps) {
     reactQuillRef.current.focus();
   }, []);
 
-  // useEffect(() => {
-  //   if (provider?.room?.bcConns.size === 0) {
-  //     // yText.insert(0, "abcde");
-  //     reactQuillRef.current.setText("Hello\n");
-  //   }
-  // }, []);
-
   useEffect(() => {
     validateText({
       text: "",
@@ -250,7 +229,6 @@ function QuillEditor(props: EditorProps) {
               setPassedRules,
               setIsCompleted,
             });
-            // console.log("text", editor.getText());
             setTextDelta(editor.getText());
           }}
         />

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -28,6 +28,8 @@ interface TextEditorProps extends ReactQuillProps {
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   setUsersInRoom: React.Dispatch<React.SetStateAction<string[]>>;
   isCompleted: boolean;
+  text: Y.Text | undefined;
+  setText: React.Dispatch<React.SetStateAction<Y.Text | undefined>>;
 }
 
 export default function TextEditor(props: TextEditorProps) {
@@ -38,8 +40,10 @@ export default function TextEditor(props: TextEditorProps) {
     slug,
     setUsersInRoom,
     isCompleted,
+    text,
+    setText,
   } = props;
-  const [text, setText] = useState<Y.Text>();
+
   const [provider, setProvider] = useState<WebrtcProviderType>();
 
   useEffect(() => {

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -201,7 +201,7 @@ function QuillEditor(props: EditorProps) {
 
   useEffect(() => {
     validateText({
-      text: "",
+      text: reactQuillRef.current?.getEditor().getText() || "",
       slug: slug,
       rules: Rules,
       setFailedRules,
@@ -268,10 +268,10 @@ function QuillEditor(props: EditorProps) {
           ) => {
             setIsLoaded(false);
             setTextDelta(editor.getText());
+
             // debounce()
             debounceRef.current?.();
             if (source === "user") {
-              // pass in source to the updateSlugRef as arg
               updateSlugRef.current?.(source);
             }
           }}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -8,5 +8,6 @@ export default defineSchema({
     passedTests: v.optional(v.number()),
     failedTests: v.optional(v.number()),
     endTime: v.optional(v.number()),
+    docText: v.string(),
   }),
 });

--- a/convex/slugs.ts
+++ b/convex/slugs.ts
@@ -25,6 +25,7 @@ export const getAllSlugs = query({
 export const createSlug = mutation({
   args: {
     slug: v.string(),
+    docText: v.string(),
   },
   handler: async (ctx, args) => {
     const existingSlug = await ctx.db
@@ -35,12 +36,14 @@ export const createSlug = mutation({
       const slugId = await ctx.db.replace(existingSlug._id, {
         slug: args.slug,
         startTime: existingSlug.startTime,
+        docText: args.docText,
       });
       return slugId;
     } else {
       const slugId = await ctx.db.insert("slugs", {
         slug: args.slug,
         startTime: Date.now(),
+        docText: args.docText,
       });
       return slugId;
     }
@@ -53,6 +56,7 @@ export const updateSlug = mutation({
     passedTests: v.number(),
     failedTests: v.number(),
     endTime: v.optional(v.number()),
+    docText: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { id } = args;
@@ -64,6 +68,7 @@ export const updateSlug = mutation({
       failedTests: args.failedTests,
       // if endTime already exists in existingSlug, don't update it
       endTime: existingSlug?.endTime ? existingSlug.endTime : args.endTime,
+      docText: args.docText ? args.docText : existingSlug?.docText,
     });
   },
 });


### PR DESCRIPTION
# Description
When the user/users complete the game, the time should stop and show completed time. It should also lock the text area when the game is complete.

In addition, when users type, the client now saves the data on convex db


## Type of change

Please remove all except for everything applicable, and then remove this line.
- New feature (non-breaking change which adds functionality)


# Checklist:

- [ ] Changes have new/updated automated tests, if applicable
- [ ] Changes have new/updated docs, if applicable
- [ ] I have performed a self-review of my own code
- [ ] I have added comments on any new, hard-to-understand code
- [ ] Changes have been manually tested
- [ ] Changes generate no new errors or warnings
