### PR TITLE
Create debounce for rule validation

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -59,7 +59,6 @@ export default function Page(props: PageParams) {
         <DocumentWrapper
           slug={slug}
           slugId={slugId}
-          usersInRoom={usersInRoom}
           setUsersInRoom={setUsersInRoom}
         />
       </div>

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -11,12 +11,11 @@ import type { Dispatch, SetStateAction } from "react";
 interface DocumentWrapperProps {
   slug: string;
   slugId: Id<"slugs"> | undefined;
-  usersInRoom: string[];
   setUsersInRoom: Dispatch<SetStateAction<string[]>>;
 }
 export default function DocumentWrapper(props: DocumentWrapperProps) {
   const updateSlug = useMutation(api.slugs.updateSlug);
-  const { slug, slugId, usersInRoom, setUsersInRoom } = props;
+  const { slug, slugId, setUsersInRoom } = props;
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
@@ -36,19 +35,19 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
 
   return (
     <div className="flex justify-center content-center flex-row gap-5">
-      {/* show 'loading...' if loading, else show 'loaded' */}
-      {isLoaded ? <h2>loaded</h2> : <h2>loading...</h2>}
-
       <TextEditor
         slug={slug}
         setPassedRules={setPassedRules}
         setFailedRules={setFailedRules}
         setIsCompleted={setIsCompleted}
         setUsersInRoom={setUsersInRoom}
-        usersInRoom={usersInRoom}
         setIsLoaded={setIsLoaded}
       />
-      <RuleSet passedRules={passedRules} failedRules={failedRules} />
+      <RuleSet
+        passedRules={passedRules}
+        failedRules={failedRules}
+        isLoaded={isLoaded}
+      />
     </div>
   );
 }

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -3,7 +3,7 @@ import RuleSet from "./RuleSet/RuleSet";
 import TextEditor from "./TextEditor";
 import { Rule } from "./RuleSet/Rules";
 import { api } from "@/convex/_generated/api";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import { Id } from "@/convex/_generated/dataModel";
 
 import type { Dispatch, SetStateAction } from "react";

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -20,6 +20,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   useEffect(() => {
     if (slugId) {
@@ -35,6 +36,9 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
 
   return (
     <div className="flex justify-center content-center flex-row gap-5">
+      {/* show 'loading...' if loading, else show 'loaded' */}
+      {isLoaded ? <h2>loaded</h2> : <h2>loading...</h2>}
+
       <TextEditor
         slug={slug}
         setPassedRules={setPassedRules}
@@ -42,6 +46,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         setIsCompleted={setIsCompleted}
         setUsersInRoom={setUsersInRoom}
         usersInRoom={usersInRoom}
+        setIsLoaded={setIsLoaded}
       />
       <RuleSet passedRules={passedRules} failedRules={failedRules} />
     </div>

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -5,10 +5,11 @@ import { BsFillEmojiAngryFill, BsFillEmojiHeartEyesFill } from "react-icons/bs";
 interface RuleSetProps {
   passedRules: Rule[];
   failedRules: Rule[];
+  isLoaded: boolean;
 }
 
 export default function RuleSet(props: RuleSetProps) {
-  const { passedRules, failedRules } = props;
+  const { passedRules, failedRules, isLoaded } = props;
 
   return (
     <div className="flex flex-col items-center align-items h-[76vh] ">

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -1,12 +1,19 @@
-import { ReactElement } from "react";
+import { CSSProperties, ReactElement } from "react";
 import { Rule } from "./Rules";
 import { BsFillEmojiAngryFill, BsFillEmojiHeartEyesFill } from "react-icons/bs";
+import PacmanLoader from "react-spinners/PacmanLoader";
 
 interface RuleSetProps {
   passedRules: Rule[];
   failedRules: Rule[];
   isLoaded: boolean;
 }
+
+const spinnerStyle: CSSProperties = {
+  display: "block",
+  margin: "0 auto",
+  borderColor: "red",
+};
 
 export default function RuleSet(props: RuleSetProps) {
   const { passedRules, failedRules, isLoaded } = props;
@@ -17,6 +24,17 @@ export default function RuleSet(props: RuleSetProps) {
         Rules (Passed: {passedRules.length} of{" "}
         {passedRules.length + failedRules.length})
       </h3>
+      {/* min height  */}
+      <div className="h-[10px] mt-1">
+        <PacmanLoader
+          color={"#36d7b7"}
+          loading={!isLoaded}
+          cssOverride={spinnerStyle}
+          size={10}
+          aria-label="Loading Spinner"
+          data-testid="loader"
+        />
+      </div>
       <div className="min-w-[20vw] p-6 min-h-[60vh] max-w-[20vw] overflow-y-auto scrollbar scrollbar-thumb-gray-900 scrollbar-track-gray-100">
         <CardList
           rules={failedRules}

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -24,7 +24,6 @@ export default function RuleSet(props: RuleSetProps) {
         Rules (Passed: {passedRules.length} of{" "}
         {passedRules.length + failedRules.length})
       </h3>
-      {/* min height  */}
       <div className="h-[10px] mt-1">
         <PacmanLoader
           color={"#36d7b7"}

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -7,11 +7,20 @@ interface ValidateTextProps {
   setPassedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   slug: string;
+  setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const validateText = (props: ValidateTextProps) => {
-  const { text, rules, setFailedRules, setPassedRules, setIsCompleted, slug } =
-    props;
+  const {
+    text,
+    rules,
+    setFailedRules,
+    setPassedRules,
+    setIsCompleted,
+    slug,
+    setIsLoaded,
+  } = props;
+  console.log("validateText", text);
 
   const failedRules: Rule[] = [];
   const passedRules: Rule[] = [];
@@ -42,4 +51,5 @@ export const validateText = (props: ValidateTextProps) => {
 
   setFailedRules(failedRules);
   setPassedRules(passedRules);
+  setIsLoaded(true);
 };

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -20,7 +20,6 @@ export const validateText = (props: ValidateTextProps) => {
     slug,
     setIsLoaded,
   } = props;
-  console.log("validateText", text);
 
   const failedRules: Rule[] = [];
   const passedRules: Rule[] = [];

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -19,7 +19,6 @@ import { api } from "@/convex/_generated/api";
 
 import "./textEditor.css";
 import "react-quill/dist/quill.core.css";
-import { Sources } from "quill";
 import debounce from "../helpers/debouce";
 import createDebouce from "../helpers/debouce";
 
@@ -29,7 +28,6 @@ interface TextEditorProps extends ReactQuillProps {
   setFailedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   setUsersInRoom: React.Dispatch<React.SetStateAction<string[]>>;
-  usersInRoom: string[];
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -40,7 +38,6 @@ export default function TextEditor(props: TextEditorProps) {
     setIsCompleted,
     slug,
     setUsersInRoom,
-    usersInRoom,
     setIsLoaded,
   } = props;
   const [text, setText] = useState<Y.Text>();
@@ -207,12 +204,7 @@ function QuillEditor(props: EditorProps) {
               userOnly: true,
             },
           }}
-          onChange={(
-            _value: string,
-            _delta: any,
-            _source: Sources,
-            editor: ReactQuill.UnprivilegedEditor
-          ) => {
+          onChange={() => {
             setIsLoaded(false);
             debounceRef.current?.();
           }}

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -14,8 +14,6 @@ import { useEffect, useRef, useState } from "react";
 import type { ReactQuillProps } from "react-quill";
 
 import { validateText } from "./RuleSet/RuleValidation";
-import { useMutation } from "convex/react";
-import { api } from "@/convex/_generated/api";
 
 import "./textEditor.css";
 import "react-quill/dist/quill.core.css";
@@ -121,7 +119,6 @@ type EditorProps = {
 };
 
 function QuillEditor(props: EditorProps) {
-  const updateSlug = useMutation(api.slugs.updateSlug);
   const {
     yText,
     provider,
@@ -178,7 +175,6 @@ function QuillEditor(props: EditorProps) {
         setIsCompleted,
         setIsLoaded,
       });
-      // setIsLoaded(true);
     }, 500);
   }, []);
 

--- a/app/helpers/debouce.ts
+++ b/app/helpers/debouce.ts
@@ -1,0 +1,26 @@
+/*
+ * Debounce a function call. When a function is debounced, it will only be called after a certain amount of time has passed since the last time * * it was called. Repeat calls to the function reset the timer.
+ * @param {Function} func - The function to debounce.
+ * @param {number} wait - The number of milliseconds to wait.
+ * @return {Function} The debounced function.
+ */
+
+export default function createDebouce(
+  func: (...args: any) => void,
+  wait: number
+) {
+  // func();
+
+  let timeout: any;
+
+  return (...args: any) => {
+    // console.log("debounce function", func, wait);
+    // func(...args);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      func(...args);
+    }, wait);
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^4.11.0",
         "react-quill": "^2.0.0",
+        "react-spinners": "^0.13.8",
         "tailwindcss": "3.3.3",
         "typescript": "5.2.2",
         "y-quill": "^0.1.5",
@@ -4674,6 +4675,15 @@
       "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
       "dependencies": {
         "parchment": "^1.1.2"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.11.0",
     "react-quill": "^2.0.0",
+    "react-spinners": "^0.13.8",
     "tailwindcss": "3.3.3",
     "typescript": "5.2.2",
     "y-quill": "^0.1.5",


### PR DESCRIPTION
# Description
Created a debounce function that now runs the rule validation on a 500ms delay.

When user types, the previous functionality was that the rules would run on every single keypress/change in input.

This change will ensure that the number of calls to the `validationText` function is dramatically reduced by debouncing the function.

Also added a fun little pacman loader for user feedback when the debounce is debouncing
## Testing

1. Start typing (fast) in the editor, the pacman loader should spin when user is typing.
2. the validationText function should be called only a couple of times (passing a rule will be delayed)
3. start typing in another browser tab and verify that the 1st tab is also being debounced


## Type of change

Please remove all except for everything applicable, and then remove this line.
- New feature (non-breaking change which adds functionality)

