### PR TITLE
bug fix: typing text types backwards

### DIFF
--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -278,7 +278,7 @@ function QuillEditor(props: EditorProps) {
           ) => {
             setIsLoaded(false);
             // TODO: fix this
-            setTextDelta(editor.getText());
+            // setTextDelta(editor.getText());
 
             // debounce()
             debounceRef.current?.();

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -277,6 +277,7 @@ function QuillEditor(props: EditorProps) {
             editor: ReactQuill.UnprivilegedEditor
           ) => {
             setIsLoaded(false);
+            // TODO: fix this
             setTextDelta(editor.getText());
 
             // debounce()

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -277,8 +277,6 @@ function QuillEditor(props: EditorProps) {
             editor: ReactQuill.UnprivilegedEditor
           ) => {
             setIsLoaded(false);
-            // TODO: fix this
-            // setTextDelta(editor.getText());
 
             // debounce()
             debounceRef.current?.();


### PR DESCRIPTION


# Description

Fix a bug where the cursor stays at the start of the text editor and it types backwards. This was due to an extra setter for text delta that has been removed
## Testing

Ensure typing works normally

## Type of change

Please remove all except for everything applicable, and then remove this line.
- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] Changes have new/updated automated tests, if applicable
- [ ] Changes have new/updated docs, if applicable
- [ ] I have performed a self-review of my own code
- [ ] I have added comments on any new, hard-to-understand code
- [ ] Changes have been manually tested
- [ ] Changes generate no new errors or warnings
