### PR TITLE
Show and validate all attempted rules as they are attempted

### DIFF
--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -44,6 +44,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         passedRules={passedRules}
         failedRules={failedRules}
         setAttemptedRules={setAttemptedRules}
+        attemptedRules={attemptedRules}
       />
       <RuleSet
         passedRules={passedRules}

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -37,14 +37,12 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         isCompleted={isCompleted}
         text={text}
         setText={setText}
-        setTextDelta={setTextDelta}
         textDelta={textDelta}
         setIsLoaded={setIsLoaded}
         slugId={slugId}
         passedRules={passedRules}
         failedRules={failedRules}
         setAttemptedRules={setAttemptedRules}
-        attemptedRules={attemptedRules}
       />
       <RuleSet
         passedRules={passedRules}

--- a/app/components/DocumentWrapper.tsx
+++ b/app/components/DocumentWrapper.tsx
@@ -21,6 +21,7 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
   const { slug, slugId, setUsersInRoom, textDelta, setTextDelta } = props;
   const [passedRules, setPassedRules] = useState<Rule[]>([]);
   const [failedRules, setFailedRules] = useState<Rule[]>([]);
+  const [attemptedRules, setAttemptedRules] = useState<Rule[]>([]);
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [text, setText] = useState<Y.Text>();
@@ -42,10 +43,12 @@ export default function DocumentWrapper(props: DocumentWrapperProps) {
         slugId={slugId}
         passedRules={passedRules}
         failedRules={failedRules}
+        setAttemptedRules={setAttemptedRules}
       />
       <RuleSet
         passedRules={passedRules}
         failedRules={failedRules}
+        attemptedRules={attemptedRules}
         isLoaded={isLoaded}
       />
     </div>

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -18,7 +18,6 @@ const spinnerStyle: CSSProperties = {
 
 export default function RuleSet(props: RuleSetProps) {
   const { passedRules, failedRules, isLoaded, attemptedRules } = props;
-  console.log("attempted rules", { attemptedRules, passedRules, failedRules });
 
   return (
     <div className="flex flex-col items-center align-items h-[76vh] ">

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -18,6 +18,7 @@ const spinnerStyle: CSSProperties = {
 
 export default function RuleSet(props: RuleSetProps) {
   const { passedRules, failedRules, isLoaded, attemptedRules } = props;
+  console.log("attempted rules", { attemptedRules, passedRules, failedRules });
 
   return (
     <div className="flex flex-col items-center align-items h-[76vh] ">

--- a/app/components/RuleSet/RuleSet.tsx
+++ b/app/components/RuleSet/RuleSet.tsx
@@ -7,6 +7,7 @@ interface RuleSetProps {
   passedRules: Rule[];
   failedRules: Rule[];
   isLoaded: boolean;
+  attemptedRules: Rule[];
 }
 
 const spinnerStyle: CSSProperties = {
@@ -16,7 +17,7 @@ const spinnerStyle: CSSProperties = {
 };
 
 export default function RuleSet(props: RuleSetProps) {
-  const { passedRules, failedRules, isLoaded } = props;
+  const { passedRules, failedRules, isLoaded, attemptedRules } = props;
 
   return (
     <div className="flex flex-col items-center align-items h-[76vh] ">
@@ -35,16 +36,7 @@ export default function RuleSet(props: RuleSetProps) {
         />
       </div>
       <div className="min-w-[20vw] p-6 min-h-[60vh] max-w-[20vw] overflow-y-auto scrollbar scrollbar-thumb-gray-900 scrollbar-track-gray-100">
-        <CardList
-          rules={failedRules}
-          SvgIcon={<BsFillEmojiAngryFill className="text-red-500 h-7 w-7" />}
-        />
-        <CardList
-          rules={passedRules}
-          SvgIcon={
-            <BsFillEmojiHeartEyesFill className="text-green-500 h-7 w-7" />
-          }
-        />
+        <CardList attemptedRules={attemptedRules} />
       </div>
     </div>
   );
@@ -66,16 +58,24 @@ function Card({ text, SvgIcon }: CardProps) {
 }
 
 type CardListProps = {
-  rules: Rule[];
-  SvgIcon: ReactElement;
+  attemptedRules: Rule[];
 };
-function CardList({ rules, SvgIcon }: CardListProps) {
+function CardList({ attemptedRules }: CardListProps) {
   return (
     <ul>
-      {rules.map((rule) => {
+      {attemptedRules.map((rule) => {
         return (
           <li key={rule.description} className="flex flex-row py-2">
-            <Card text={rule.description} SvgIcon={SvgIcon} />
+            <Card
+              text={rule.description}
+              SvgIcon={
+                rule.isPassing ? (
+                  <BsFillEmojiHeartEyesFill className="text-green-500 h-7 w-7" />
+                ) : (
+                  <BsFillEmojiAngryFill className="text-red-500 h-7 w-7" />
+                )
+              }
+            />
           </li>
         );
       })}

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -8,6 +8,7 @@ interface ValidateTextProps {
   setIsCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   slug: string;
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
+  setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
 }
 
 export const validateText = (props: ValidateTextProps) => {
@@ -19,11 +20,13 @@ export const validateText = (props: ValidateTextProps) => {
     setIsCompleted,
     slug,
     setIsLoaded,
+    setAttemptedRules,
   } = props;
 
   const failedRules: Rule[] = [];
   const passedRules: Rule[] = [];
 
+  // attempted rules should validate every time the user types
   if (text.length === 0) {
     failedRules.push(rules[0]);
   } else {
@@ -36,11 +39,28 @@ export const validateText = (props: ValidateTextProps) => {
       const rule = rules[i];
       if (!rule.validation(text, slug)) {
         rule.completed = false;
+        rule.isPassing = false;
         failedRules.push(rule);
       } else {
         rule.completed = true;
+        rule.isPassing = true;
         passedRules.push(rule);
       }
+
+      // sort failing a the top, passing at the bottom
+      setAttemptedRules((prevRules) =>
+        [...prevRules, rule]
+          .filter((rule, index, self) => index === self.indexOf(rule))
+          .sort((a, b) => {
+            if (a.isPassing && !b.isPassing) {
+              return 1;
+            } else if (!a.isPassing && b.isPassing) {
+              return -1;
+            } else {
+              return 0;
+            }
+          })
+      );
     }
   }
 

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -9,7 +9,6 @@ interface ValidateTextProps {
   slug: string;
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
-  attemptedRules: Rule[];
 }
 
 export const validateText = (props: ValidateTextProps) => {
@@ -22,7 +21,6 @@ export const validateText = (props: ValidateTextProps) => {
     slug,
     setIsLoaded,
     setAttemptedRules,
-    attemptedRules,
   } = props;
 
   const failedRules: Rule[] = [];

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -43,12 +43,8 @@ export const validateText = (props: ValidateTextProps) => {
       rule.attempted = true;
       if (!rule.validation(text, slug)) {
         rule.completed = false;
-        // rule.isPassing = false;
-        // failedRules.push(rule);
       } else {
         rule.completed = true;
-        // rule.isPassing = true;
-        // passedRules.push(rule);
       }
 
       // sort failing a the top, passing at the bottom

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -9,6 +9,7 @@ interface ValidateTextProps {
   slug: string;
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
+  attemptedRules: Rule[];
 }
 
 export const validateText = (props: ValidateTextProps) => {
@@ -21,6 +22,7 @@ export const validateText = (props: ValidateTextProps) => {
     slug,
     setIsLoaded,
     setAttemptedRules,
+    attemptedRules,
   } = props;
 
   const failedRules: Rule[] = [];
@@ -31,20 +33,22 @@ export const validateText = (props: ValidateTextProps) => {
     failedRules.push(rules[0]);
   } else {
     for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
       const prevRule = rules[i - 1];
+
       if (prevRule && !prevRule.completed) {
         break;
       }
 
-      const rule = rules[i];
+      rule.attempted = true;
       if (!rule.validation(text, slug)) {
         rule.completed = false;
-        rule.isPassing = false;
-        failedRules.push(rule);
+        // rule.isPassing = false;
+        // failedRules.push(rule);
       } else {
         rule.completed = true;
-        rule.isPassing = true;
-        passedRules.push(rule);
+        // rule.isPassing = true;
+        // passedRules.push(rule);
       }
 
       // sort failing a the top, passing at the bottom
@@ -61,6 +65,19 @@ export const validateText = (props: ValidateTextProps) => {
             }
           })
       );
+    }
+
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      if (rule.attempted) {
+        if (!rule.validation(text, slug)) {
+          rule.isPassing = false;
+          failedRules.push(rule);
+        } else {
+          rule.isPassing = true;
+          passedRules.push(rule);
+        }
+      }
     }
   }
 

--- a/app/components/RuleSet/RuleValidation.ts
+++ b/app/components/RuleSet/RuleValidation.ts
@@ -48,19 +48,7 @@ export const validateText = (props: ValidateTextProps) => {
       }
 
       // sort failing a the top, passing at the bottom
-      setAttemptedRules((prevRules) =>
-        [...prevRules, rule]
-          .filter((rule, index, self) => index === self.indexOf(rule))
-          .sort((a, b) => {
-            if (a.isPassing && !b.isPassing) {
-              return 1;
-            } else if (!a.isPassing && b.isPassing) {
-              return -1;
-            } else {
-              return 0;
-            }
-          })
-      );
+      setAttemptedRules((prevRules) => [...prevRules, rule]);
     }
 
     for (let i = 0; i < rules.length; i++) {
@@ -81,6 +69,24 @@ export const validateText = (props: ValidateTextProps) => {
     setIsCompleted(true);
   }
 
+  // sort and filter out duplicates from the attempted rules
+  setAttemptedRules((prevRules) =>
+    [...prevRules]
+      .filter(
+        (rule, index, self) =>
+          index === self.findIndex((r) => r.name === rule.name)
+      )
+      .sort((a, b) => {
+        // sort based on passed or not. Failed rules should be at the top
+        if (a.isPassing && !b.isPassing) {
+          return 1;
+        } else if (!a.isPassing && b.isPassing) {
+          return -1;
+        } else {
+          return 0;
+        }
+      })
+  );
   setFailedRules(failedRules);
   setPassedRules(passedRules);
   setIsLoaded(true);

--- a/app/components/RuleSet/Rules.ts
+++ b/app/components/RuleSet/Rules.ts
@@ -51,43 +51,14 @@ export const Rules: RuleStore = [
     name: "Continue the story-1",
     description: "There's not enough words here. Add some more",
     validation: (text: string) => {
-      const firstSentence = (text: string) => {
-        const firstSlice = text
-          .toLowerCase()
-          .slice(0, 100)
-          .replace(/\n$/, "")
-          .trim();
-        //  match the first sentence with fairy tale beginning and grab that sentence
-        const firstSentenceSlice = fairyTaleBeginnings.find((beginning) =>
-          firstSlice.startsWith(beginning.toLowerCase().trim())
-        );
-        return firstSentenceSlice ? firstSentenceSlice : "";
-      };
+      // clean up the text by removing line break and extra spaces
+      const cleanedText = text.replace(/\n/g, " ").replace(/\s+/g, " ");
+      const words = cleanedText.split(" ");
 
-      const lastSentence = (text: string) => {
-        const lastSlice = text
-          .toLowerCase()
-          .slice(-100)
-          .replace(/\n$/, "")
-          .trim();
-        //  match the last sentence with 'the end' and grab that sentence
-        const lastSentenceSlice = lastSlice.endsWith("the end")
-          ? "the end"
-          : "";
-        return lastSentenceSlice;
-      };
+      const wordCount = words.length;
+      const isPassing = wordCount >= 20;
 
-      const firstSentenceIndex = text.indexOf(firstSentence(text));
-      const lastSentenceIndex = text.indexOf(lastSentence(text));
-
-      const textBetweenFirstAndLastSentence = text.slice(
-        firstSentenceIndex + firstSentence(text).length,
-        lastSentenceIndex
-      );
-
-      const words = textBetweenFirstAndLastSentence.match(/[^ ,\-\n]+/g);
-
-      return words ? words.length >= 10 : false;
+      return isPassing;
     },
   },
   {

--- a/app/components/RuleSet/Rules.ts
+++ b/app/components/RuleSet/Rules.ts
@@ -17,6 +17,7 @@ export interface Rule {
   validation: (text: string, slug?: string) => boolean;
   completed?: boolean;
   isPassing?: boolean;
+  attempted?: boolean;
 }
 
 interface RuleStore extends Array<Rule> {}

--- a/app/components/RuleSet/Rules.ts
+++ b/app/components/RuleSet/Rules.ts
@@ -16,6 +16,7 @@ export interface Rule {
   description: string;
   validation: (text: string, slug?: string) => boolean;
   completed?: boolean;
+  isPassing?: boolean;
 }
 
 interface RuleStore extends Array<Rule> {}

--- a/app/components/RuleSet/getMatches.ts
+++ b/app/components/RuleSet/getMatches.ts
@@ -1,5 +1,3 @@
-import { digits } from "./ValidationLists";
-
 const arrayToRegex = (stringsToMatch: string[], options: string): RegExp => {
   // Escape any special characters in the input strings and join them with the "|" (OR) operator.
   const escapedStrings = stringsToMatch.map((str) =>

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -277,7 +277,7 @@ function QuillEditor(props: EditorProps) {
             editor: ReactQuill.UnprivilegedEditor
           ) => {
             setIsLoaded(false);
-            setTextDelta(editor.getText());
+            // setTextDelta(editor.getText());
 
             // debounce()
             debounceRef.current?.();

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -43,6 +43,7 @@ interface TextEditorProps extends ReactQuillProps {
   passedRules: Rule[];
   failedRules: Rule[];
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
+  attemptedRules: Rule[];
 }
 
 export default function TextEditor(props: TextEditorProps) {
@@ -62,6 +63,7 @@ export default function TextEditor(props: TextEditorProps) {
     passedRules,
     failedRules,
     setAttemptedRules,
+    attemptedRules,
   } = props;
 
   const [provider, setProvider] = useState<WebrtcProviderType>();
@@ -135,6 +137,7 @@ export default function TextEditor(props: TextEditorProps) {
         slugId={slugId}
         passedRules={passedRules}
         failedRules={failedRules}
+        setAttemptedRules={setAttemptedRules}
       />
     </div>
   );
@@ -155,6 +158,7 @@ type EditorProps = {
   passedRules: Rule[];
   failedRules: Rule[];
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
+  attemptedRules: Rule[];
 };
 
 function QuillEditor(props: EditorProps) {
@@ -173,6 +177,7 @@ function QuillEditor(props: EditorProps) {
     passedRules,
     failedRules,
     setAttemptedRules,
+    attemptedRules,
   } = props;
   const reactQuillRef = useRef<ReactQuill>(null);
   const debounceRef = useRef<ReturnType<typeof debounce>>();
@@ -223,6 +228,7 @@ function QuillEditor(props: EditorProps) {
       setIsCompleted,
       setIsLoaded,
       setAttemptedRules,
+      attemptedRules,
     });
   }, [setFailedRules, setIsCompleted, setPassedRules]);
 
@@ -237,6 +243,7 @@ function QuillEditor(props: EditorProps) {
         setIsCompleted,
         setIsLoaded,
         setAttemptedRules,
+        attemptedRules,
       });
     }, 1000);
 

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -42,6 +42,7 @@ interface TextEditorProps extends ReactQuillProps {
   slugId?: Id<"slugs"> | undefined;
   passedRules: Rule[];
   failedRules: Rule[];
+  setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
 }
 
 export default function TextEditor(props: TextEditorProps) {
@@ -60,6 +61,7 @@ export default function TextEditor(props: TextEditorProps) {
     slugId,
     passedRules,
     failedRules,
+    setAttemptedRules,
   } = props;
 
   const [provider, setProvider] = useState<WebrtcProviderType>();
@@ -152,6 +154,7 @@ type EditorProps = {
   slugId?: Id<"slugs"> | undefined;
   passedRules: Rule[];
   failedRules: Rule[];
+  setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
 };
 
 function QuillEditor(props: EditorProps) {
@@ -169,6 +172,7 @@ function QuillEditor(props: EditorProps) {
     slugId,
     passedRules,
     failedRules,
+    setAttemptedRules,
   } = props;
   const reactQuillRef = useRef<ReactQuill>(null);
   const debounceRef = useRef<ReturnType<typeof debounce>>();
@@ -218,6 +222,7 @@ function QuillEditor(props: EditorProps) {
       setPassedRules,
       setIsCompleted,
       setIsLoaded,
+      setAttemptedRules,
     });
   }, [setFailedRules, setIsCompleted, setPassedRules]);
 
@@ -231,6 +236,7 @@ function QuillEditor(props: EditorProps) {
         setPassedRules,
         setIsCompleted,
         setIsLoaded,
+        setAttemptedRules,
       });
     }, 1000);
 

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -202,8 +202,6 @@ function QuillEditor(props: EditorProps) {
       return;
     }
 
-    console.log("textDelta:", textDelta);
-
     const quill = reactQuillRef.current.getEditor();
     if (provider?.room?.bcConns.size === 0) {
       quill.setText(textDelta);

--- a/app/components/TextEditor.tsx
+++ b/app/components/TextEditor.tsx
@@ -37,13 +37,12 @@ interface TextEditorProps extends ReactQuillProps {
   text: Y.Text | undefined;
   setText: React.Dispatch<React.SetStateAction<Y.Text | undefined>>;
   textDelta: string;
-  setTextDelta: React.Dispatch<React.SetStateAction<string>>;
+
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
   slugId?: Id<"slugs"> | undefined;
   passedRules: Rule[];
   failedRules: Rule[];
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
-  attemptedRules: Rule[];
 }
 
 export default function TextEditor(props: TextEditorProps) {
@@ -56,14 +55,12 @@ export default function TextEditor(props: TextEditorProps) {
     isCompleted,
     text,
     setText,
-    setTextDelta,
     textDelta,
     setIsLoaded,
     slugId,
     passedRules,
     failedRules,
     setAttemptedRules,
-    attemptedRules,
   } = props;
 
   const [provider, setProvider] = useState<WebrtcProviderType>();
@@ -132,7 +129,6 @@ export default function TextEditor(props: TextEditorProps) {
         isCompleted={isCompleted}
         slug={slug}
         textDelta={textDelta}
-        setTextDelta={setTextDelta}
         setIsLoaded={setIsLoaded}
         slugId={slugId}
         passedRules={passedRules}
@@ -152,13 +148,12 @@ type EditorProps = {
   slug: string;
   isCompleted: boolean;
   textDelta: string;
-  setTextDelta: React.Dispatch<React.SetStateAction<string>>;
+
   setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
   slugId?: Id<"slugs"> | undefined;
   passedRules: Rule[];
   failedRules: Rule[];
   setAttemptedRules: React.Dispatch<React.SetStateAction<Rule[]>>;
-  attemptedRules: Rule[];
 };
 
 function QuillEditor(props: EditorProps) {
@@ -171,13 +166,12 @@ function QuillEditor(props: EditorProps) {
     slug,
     isCompleted,
     textDelta,
-    setTextDelta,
+
     setIsLoaded,
     slugId,
     passedRules,
     failedRules,
     setAttemptedRules,
-    attemptedRules,
   } = props;
   const reactQuillRef = useRef<ReactQuill>(null);
   const debounceRef = useRef<ReturnType<typeof debounce>>();
@@ -226,7 +220,6 @@ function QuillEditor(props: EditorProps) {
       setIsCompleted,
       setIsLoaded,
       setAttemptedRules,
-      attemptedRules,
     });
   }, [setFailedRules, setIsCompleted, setPassedRules]);
 
@@ -241,7 +234,6 @@ function QuillEditor(props: EditorProps) {
         setIsCompleted,
         setIsLoaded,
         setAttemptedRules,
-        attemptedRules,
       });
     }, 1000);
 


### PR DESCRIPTION


# Description
Previously only 1 failing rule got validated at a time. Now once the user passes a previous rule, the current rule is marked at attempted. All attempted rules show as passing/failing and are validated all the time.

## Testing

Multiple failing tests should show once they have been attempted. 

All the rules should NOT be shown. Only the attempted ones should be.

## Type of change

Please remove all except for everything applicable, and then remove this line.

- New feature (non-breaking change which adds functionality)


# Checklist:

- [ ] Changes have new/updated automated tests, if applicable
- [ ] Changes have new/updated docs, if applicable
- [ ] I have performed a self-review of my own code
- [ ] I have added comments on any new, hard-to-understand code
- [ ] Changes have been manually tested
- [ ] Changes generate no new errors or warnings
